### PR TITLE
Update User.java

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/User.java
+++ b/intercom-java/src/main/java/io/intercom/api/User.java
@@ -38,7 +38,6 @@ public class User extends TypedData implements Replier {
     public static User find(String id)
         throws AuthorizationException, ClientException, ServerException, InvalidException, RateLimitException {
         final URI users = UriBuilder.newBuilder().path("users").path(id).build();
-        System.out.println(users.toASCIIString());
         final HttpClient resource = new HttpClient(users);
         return resource.get(User.class);
     }


### PR DESCRIPTION
remove println. I also noticed this printline used to print https://api.intercom.io//users/xxx with a double slash, so you probably also want to remove the trailing slash in Intercom.java:

 private static final URI API_BASE_URI = URI.create("https://api.intercom.io/");

However, haven't tested this for all methods
