### PR TITLE
resolve conflicting getter definitions error for jackson

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/User.java
+++ b/intercom-java/src/main/java/io/intercom/api/User.java
@@ -227,20 +227,10 @@ public class User extends TypedData implements Replier {
             return unsubscribedFromEmails;
         }
 
-        public Boolean getUpdateLastRequestAt() {
-            return updateLastRequestAt;
-        }
-
-        public Boolean getNewSession() {
-            return newSession;
-        }
-
-        @Deprecated
         public Boolean isUpdateLastRequestAt() {
             return updateLastRequestAt;
         }
 
-        @Deprecated
         public Boolean isNewSession() {
             return newSession;
         }

--- a/intercom-java/src/test/java/io/intercom/api/UserTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/UserTest.java
@@ -6,13 +6,9 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.intercom.api.TestSupport.load;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class UserTest {
 
@@ -61,8 +57,6 @@ public class UserTest {
          check we didn't set unsubscribed_from_emails, update_last_request_at, or
          new_session by default
          */
-        assertEquals(null, userUpdate.getNewSession());
-        assertEquals(null, userUpdate.getUnsubscribedFromEmails());
         assertEquals(null, userUpdate.getUnsubscribedFromEmails());
         assertEquals(null, userUpdate.isNewSession());
         assertEquals(null, userUpdate.isUpdateLastRequestAt());
@@ -97,8 +91,6 @@ public class UserTest {
 
         final User.UserUpdate userUpdate = User.UserUpdate.buildFrom(user);
 
-        assertEquals(true, userUpdate.getNewSession());
-        assertEquals(true, userUpdate.getUnsubscribedFromEmails());
         assertEquals(true, userUpdate.getUnsubscribedFromEmails());
         assertEquals(true, userUpdate.isNewSession());
         assertEquals(true, userUpdate.isUpdateLastRequestAt());


### PR DESCRIPTION
for #48 looks like some older jackson versions don't want to see multiple getters for a given field. This removes secondary getters added in 1.0.8