### PR TITLE
Allow open and close admin replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ ConversationCollection openForAdmin = Conversation.list(params);
 Admin admin = new Admin().setId("1");
 AdminReply adminReply = new AdminReply(admin);
 adminReply.setBody("These apples are healthsome");
+Conversation.reply("66", adminReply); 
+
+// admin close
+Admin admin = new Admin().setId("1");
+AdminReply adminReply = new AdminReply(admin);
+adminReply.setMessageType("close");
 Conversation.reply("66", adminReply);
 
 // user reply

--- a/intercom-java/src/main/java/io/intercom/api/AdminReply.java
+++ b/intercom-java/src/main/java/io/intercom/api/AdminReply.java
@@ -41,10 +41,32 @@ public class AdminReply extends Reply<Admin> {
         public String getAdminID() {
             return reply.getFrom().getId();
         }
+
+        @JsonProperty("assignee_id")
+        public String getAssigneeID() {
+            return reply.getAssigneeID();
+        }
     }
+
+    @JsonProperty("assignee_id")
+    private String assigneeID;
 
     public AdminReply(Admin admin) {
         this.from = admin;
+    }
+
+    public Reply<Admin> setMessageType(String messageType) {
+        return setMessageReplyType(messageType);
+    }
+
+    public String getAssigneeID() {
+        return assigneeID;
+    }
+
+    public Reply<Admin> setAssigneeID(String assigneeID) {
+        this.assigneeID = assigneeID;
+        this.setMessageType("assign");
+        return this;
     }
 
     @Override

--- a/intercom-java/src/main/java/io/intercom/api/Reply.java
+++ b/intercom-java/src/main/java/io/intercom/api/Reply.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 class Reply<T extends Replier> extends TypedData {
 
     @JsonProperty("message_type")
-    private final String messageType = "comment";
+    private String messageType = "comment";
 
     @JsonProperty("body")
     private String body;
@@ -42,6 +42,11 @@ class Reply<T extends Replier> extends TypedData {
 
     String getMessageType() {
         return messageType;
+    }
+
+    Reply<T> setMessageReplyType(String messageType) {
+        this.messageType = messageType;
+        return this;
     }
 
     @Override

--- a/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
@@ -5,10 +5,60 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class ConversationTest {
+
+    @Test
+    public void testIsNullOrBlank() {
+        assertTrue(Conversation.isNullOrBlank(null));
+        assertTrue(Conversation.isNullOrBlank(""));
+        assertTrue(Conversation.isNullOrBlank(" "));
+        assertTrue(Conversation.isNullOrBlank("\n"));
+        assertTrue(Conversation.isNullOrBlank("\r"));
+        assertFalse(Conversation.isNullOrBlank("reply"));
+    }
+
+    @Test
+    public void testAdminReply() {
+
+        AdminReply adminReply = new AdminReply(null);
+        adminReply.setAssigneeID("1");
+        assertEquals("assign", adminReply.getMessageType());
+
+        try {
+            Conversation.validateAdminReplyRequest(adminReply);
+        } catch (InvalidException e) {
+            fail();
+        }
+
+        adminReply = new AdminReply(null);
+        adminReply.setMessageType("comment");
+        try {
+            Conversation.validateAdminReplyRequest(adminReply);
+            fail();
+        } catch (InvalidException e) {
+            assertTrue(e.getMessage()
+                .contains("a comment or note reply must have a body"));
+        }
+
+        adminReply.setBody(" ");
+        try {
+            Conversation.validateAdminReplyRequest(adminReply);
+            fail();
+        } catch (InvalidException e) {
+            assertTrue(e.getMessage()
+                .contains("a comment or note reply must have a body"));
+        }
+
+        adminReply.setBody("Once, in flight school, I was laconic");
+        try {
+            Conversation.validateAdminReplyRequest(adminReply);
+        } catch (InvalidException e) {
+            fail();
+        }
+    }
 
     @Test
     public void testDisplayAs() {


### PR DESCRIPTION
Send open or close admin replies, optionally with a
body and allow conversations to be assigned to pther
admings  with some validation to check combinations of
fields. Also while we're here, validate that a user
reply has a message type of comment.