### PR TITLE
Configure Jackson ObjectMapper once

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
+++ b/intercom-java/src/main/java/io/intercom/api/MapperSupport.java
@@ -9,34 +9,32 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 public class MapperSupport {
 
     public static ObjectMapper objectMapper() {
-        final ObjectMapper om = Holder.INSTANCE;
-        configure(om);
-        return om;
-    }
-
-    private static void configure(ObjectMapper objectMapper) {
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true);
-        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        objectMapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
-        objectMapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
-        objectMapper.registerModule(customAttributeModule());
-    }
-
-    private static SimpleModule customAttributeModule() {
-        final SimpleModule customAttributeModule = new SimpleModule(
-            "IntercomClientModule",
-            new Version(1, 0, 0, null, "", "")
-        );
-        customAttributeModule.addDeserializer(CustomAttribute.class, new CustomAttributeDeserializer());
-        customAttributeModule.addSerializer(CustomAttribute.class, new CustomAttributeSerializer());
-        customAttributeModule.addDeserializer(Subscription.Topic.class, new TopicDeserializer());
-        customAttributeModule.addSerializer(Subscription.Topic.class, new TopicSerializer());
-        customAttributeModule.addSerializer(Counts.CountItem.class, new CountItemSerializer());
-        customAttributeModule.addDeserializer(Counts.CountItem.class, new CountItemDeserializer());
-        return customAttributeModule;
+        return Holder.INSTANCE;
     }
 
     private static class Holder {
-        private static final ObjectMapper INSTANCE = new ObjectMapper();
+        private static final ObjectMapper INSTANCE = new Holder().configure(new ObjectMapper());
+
+        private ObjectMapper configure(ObjectMapper om) {
+            return om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+                    .configure(SerializationFeature.INDENT_OUTPUT, true)
+                    .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+                    .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
+                    .registerModule(customAttributeModule());
+        }
+
+        private SimpleModule customAttributeModule() {
+            final SimpleModule customAttributeModule = new SimpleModule(
+                    "IntercomClientModule",
+                    new Version(1, 0, 0, null, "", "")
+            );
+            customAttributeModule.addDeserializer(CustomAttribute.class, new CustomAttributeDeserializer());
+            customAttributeModule.addSerializer(CustomAttribute.class, new CustomAttributeSerializer());
+            customAttributeModule.addDeserializer(Subscription.Topic.class, new TopicDeserializer());
+            customAttributeModule.addSerializer(Subscription.Topic.class, new TopicSerializer());
+            customAttributeModule.addSerializer(Counts.CountItem.class, new CountItemSerializer());
+            customAttributeModule.addDeserializer(Counts.CountItem.class, new CountItemDeserializer());
+            return customAttributeModule;
+        }
     }
 }


### PR DESCRIPTION
This changes the initialization on demand holder for
ObjectMapper to configure the mapper once. Previously
the mapper was being created once but reconfigured on
each access.

Fix for #76