### PR TITLE
remove user from company fix

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/CompanyUpdateBuilder.java
+++ b/intercom-java/src/main/java/io/intercom/api/CompanyUpdateBuilder.java
@@ -1,46 +1,68 @@
 package io.intercom.api;
 
+import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.collect.Lists;
 
-import java.util.ArrayList;
-import java.util.List;
-
 class CompanyUpdateBuilder {
 
-    /**
-     * Provide restrictions on the company data that can be sent via a user update
-     */
-    static List<CompanyWithStringPlan> buildUserUpdateCompanies(CompanyCollection add, CompanyCollection remove) {
+	/**
+	 * Provide restrictions on the company data that can be sent via a user
+	 * update
+	 */
+	static List<CompanyWithStringPlan> buildUserUpdateCompanies(CompanyCollection add, CompanyCollection remove) {
 
-        final ArrayList<CompanyWithStringPlan> updatableCompanies = Lists.newArrayList();
-        if (add != null) {
-            final List<Company> companies = add.getPage();
-            for (Company company : companies) {
-                updatableCompanies.add(prepareUpdatableCompany(company));
-            }
-        }
+		final List<CompanyWithStringPlan> updatableCompanies = Lists.newArrayList();
+		if (add != null) {
+			final List<Company> companies = add.getPage();
+			for (Company company : companies) {
+				updatableCompanies.add(prepareUpdatableCompany(company));
+			}
+		}
 
-        if (remove != null) {
-            final List<Company> companies = remove.getPage();
-            for (Company company : companies) {
-                updatableCompanies.add(prepareUpdatableCompany(company).setRemove(Boolean.TRUE));
-            }
-        }
+		if (remove != null) {
+			final List<Company> companies = remove.getPage();
 
-        return updatableCompanies;
-    }
+			for (Company company : companies) {
+				removeCompanyFromAddedList(updatableCompanies, company);
+				updatableCompanies.add(prepareUpdatableCompany(company).setRemove(Boolean.TRUE));
+			}
+		}
 
-    private static CompanyWithStringPlan prepareUpdatableCompany(Company company) {
-        final CompanyWithStringPlan updatableCompany = new CompanyWithStringPlan();
-        updatableCompany.setCompanyID(company.getCompanyID());
-        updatableCompany.setName(company.getName());
-        updatableCompany.setSessionCount(company.getSessionCount());
-        updatableCompany.setMonthlySpend(company.getMonthlySpend());
-        updatableCompany.setRemoteCreatedAt(company.getRemoteCreatedAt());
-        if (company.getPlan() != null) {
-            updatableCompany.setPlan(company.getPlan().getName());
-        }
-        return updatableCompany;
-    }
+		return updatableCompanies;
+	}
+
+	private static void removeCompanyFromAddedList(List<CompanyWithStringPlan> companies, Company company) {
+		Iterator<CompanyWithStringPlan> companyIterator = companies.iterator();
+
+		while (companyIterator.hasNext()) {
+			CompanyWithStringPlan companyWithStringPlan = companyIterator.next();
+			// TODO add equals and toHash methods to CompanyWithStringPlan and
+			// use it here
+			if (companyWithStringPlan.getId() != null && company.getId() != null && companyWithStringPlan.getId().equals(company.getId())) {
+				companyIterator.remove();
+				break;
+			}
+
+			if (companyWithStringPlan.getCompanyID() != null && company.getCompanyID() != null && companyWithStringPlan.getCompanyID().equals(company.getCompanyID())) {
+				companyIterator.remove();
+				break;
+			}
+		}
+	}
+
+	private static CompanyWithStringPlan prepareUpdatableCompany(Company company) {
+		final CompanyWithStringPlan updatableCompany = new CompanyWithStringPlan();
+		updatableCompany.setId(company.getId());
+		updatableCompany.setCompanyID(company.getCompanyID());
+		updatableCompany.setName(company.getName());
+		updatableCompany.setSessionCount(company.getSessionCount());
+		updatableCompany.setMonthlySpend(company.getMonthlySpend());
+		updatableCompany.setRemoteCreatedAt(company.getRemoteCreatedAt());
+		if (company.getPlan() != null) {
+			updatableCompany.setPlan(company.getPlan().getName());
+		}
+		return updatableCompany;
+	}
 }

--- a/intercom-java/src/test/java/io/intercom/api/CompanyUpdateBuilderTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/CompanyUpdateBuilderTest.java
@@ -1,63 +1,65 @@
 package io.intercom.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 
 public class CompanyUpdateBuilderTest {
 
-    private static ObjectMapper mapper;
+	private static ObjectMapper mapper;
 
-    @BeforeClass
-    public static void beforeClass() {
-        mapper = MapperSupport.objectMapper();
-    }
+	@BeforeClass
+	public static void beforeClass() {
+		mapper = MapperSupport.objectMapper();
+	}
 
+	@Test
+	public void testRemove() throws Exception {
 
-    @Test
-    public void testRemove() throws Exception {
+		final Company bacon = new Company().setCompanyID("bacon");
+		final Company pancake = new Company().setCompanyID("pancake");
 
-        final Company bacon = new Company().setCompanyID("bacon");
-        final Company pancake = new Company().setCompanyID("pancake");
+		final List<CompanyWithStringPlan> cos = CompanyUpdateBuilder.buildUserUpdateCompanies(//
+				new CompanyCollection(Lists.newArrayList(bacon, pancake)),//
+				new CompanyCollection(Lists.newArrayList(bacon)));
 
-        final List<CompanyWithStringPlan> cos = CompanyUpdateBuilder.buildUserUpdateCompanies(
-            new CompanyCollection(Lists.newArrayList(pancake)),
-            new CompanyCollection(Lists.newArrayList(bacon))
-        );
+		Boolean baconIsRemoved = null;
+		Boolean pancakeIsRemoved = null;
 
-        Boolean baconIsRemoved = null;
-        Boolean pancakeIsRemoved = null;
+		CompanyWithStringPlan baconCo = null;
+		CompanyWithStringPlan pancakeCo = null;
 
-        CompanyWithStringPlan baconCo = null;
-        CompanyWithStringPlan pancakeCo = null;
+		for (CompanyWithStringPlan co : cos) {
+			if (co.getCompanyID().equals("pancake")) {
+				pancakeIsRemoved = co.getRemove();
+				pancakeCo = co;
+			}
 
-        for (CompanyWithStringPlan co : cos) {
-            if (co.getCompanyID().equals("pancake")) {
-                pancakeIsRemoved = co.getRemove();
-                pancakeCo = co;
-            }
+			if (co.getCompanyID().equals("bacon")) {
+				baconIsRemoved = co.getRemove();
+				baconCo = co;
+			}
 
-            if (co.getCompanyID().equals("bacon")) {
-                baconIsRemoved = co.getRemove();
-                baconCo = co;
-            }
+		}
+		assertNull(pancakeIsRemoved);
+		assertTrue(baconIsRemoved);
 
-        }
-        assertNull(pancakeIsRemoved);
-        assertTrue(baconIsRemoved);
+		final String pancakeJson = mapper.writeValueAsString(pancakeCo);
+		assertFalse(pancakeJson.contains("remove"));
+		assertFalse(pancakeJson.contains("true"));
 
-        final String pancakeJson = mapper.writeValueAsString(pancakeCo);
-        assertFalse(pancakeJson.contains("remove"));
-        assertFalse(pancakeJson.contains("true"));
+		final String baconJson = mapper.writeValueAsString(baconCo);
+		assertTrue(baconJson.contains("remove"));
+		assertTrue(baconJson.contains("true"));
 
-        final String baconJson = mapper.writeValueAsString(baconCo);
-        assertTrue(baconJson.contains("remove"));
-        assertTrue(baconJson.contains("true"));
-    }
+	}
 
 }


### PR DESCRIPTION
Hello, 
 I have fixed a bug Cannot remove users from Company https://github.com/intercom/intercom-java/issues/70 .

Lets observe this code:
```
Company company = ...
Map<String, String> propertyMap = Maps.newHashMap();
propertyMap.put("company_id", company.getCompanyID());

User user = Company.listUsers(propertyMap).next();//get first user from the list


// remove user from company, important note is that this user already has company in his CompanyCollection.
user.removeCompany(company); 
...

```
In the  line where removeCompany is called we add company to RemoveCompanyCollection and this is good part but company is not removed from CompanyCollection and at the same time we allow adding already removed company. This results in not removing the user from company.


Solution to the problem is to filter CompanyCollection and remove all Companies from RemoveCompanyCollection.
