### PR TITLE
fix metadata de-serialization

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Subscription.java
+++ b/intercom-java/src/main/java/io/intercom/api/Subscription.java
@@ -12,6 +12,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
 
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -226,7 +227,7 @@ public class Subscription extends TypedData {
     private List<Topic> topics = Lists.newArrayList();
 
     @JsonProperty("metadata")
-    private Map<String, String> metadata = Maps.newHashMap();
+    private Map<String, ArrayList<String>> metadata = Maps.newHashMap();
 
     @JsonProperty("active")
     private boolean active;
@@ -310,11 +311,11 @@ public class Subscription extends TypedData {
         this.active = active;
     }
 
-    public Map<String, String> getMetadata() {
+    public Map<String, ArrayList<String>> getMetadata() {
         return metadata;
     }
 
-    public void setMetadata(Map<String, String> metadata) {
+    public void setMetadata(Map<String, ArrayList<String>> metadata) {
         this.metadata = metadata;
     }
 


### PR DESCRIPTION
The metadata field is currently only used for event webhooks (AFAIK!).

The structure is:

```json
"metadata": {
  "event_names": ["foo"]
}
```

If there is a way to make Jackson generic here I'd like to know it. But this is a fix that will work for the forseeable future.