### PR TITLE
Expose links in `Conversation` objects

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -276,6 +276,10 @@ public class Conversation extends TypedData {
         return read;
     }
 
+    public Map<String, URI> getLinks() {
+        return links;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
`Conversation` objects maintain a map of links internally, but don't expose it to the public. I think this might be an oversight; we definitely have a use case where the links would be really handy.

Thanks for your consideration!
