### PR TITLE
added X-RateLimit* fields to RateLimit exception

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/RateLimitException.java
+++ b/intercom-java/src/main/java/io/intercom/api/RateLimitException.java
@@ -4,6 +4,12 @@ public class RateLimitException extends IntercomException {
 
     private static final long serialVersionUID = -6100754169056165622L;
 
+    private int rateLimit;
+
+    private int remainingRequests;
+
+    private long resetTime;
+
     public RateLimitException(String message) {
         super(message);
     }
@@ -16,7 +22,39 @@ public class RateLimitException extends IntercomException {
         super(errorCollection);
     }
 
+    public RateLimitException(ErrorCollection errorCollection, int rateLimit,
+            int remainingRequests, long resetTime) {
+        super(errorCollection);
+        this.rateLimit = rateLimit;
+        this.remainingRequests = remainingRequests;
+        this.resetTime = resetTime;
+    }
+
     public RateLimitException(ErrorCollection errorCollection, Throwable cause) {
         super(errorCollection, cause);
+    }
+
+    public int getRateLimit() {
+        return rateLimit;
+    }
+
+    public void setRateLimit(int rateLimit) {
+        this.rateLimit = rateLimit;
+    }
+
+    public int getRemainingRequests() {
+        return remainingRequests;
+    }
+
+    public void setRemainingRequests(int remainingRequests) {
+        this.remainingRequests = remainingRequests;
+    }
+
+    public long getResetTime() {
+        return resetTime;
+    }
+
+    public void setResetTime(long resetTime) {
+        this.resetTime = resetTime;
     }
 }


### PR DESCRIPTION
Added three fields (limit, remaining requests, reset time) to RateLimitException to make it more informative and allow usage of more versatile rate controlling mechanisms.

Also let me know if you want me to bump up the lib version.