### PR TITLE
Add support for retrieving conversation tags

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -199,6 +199,9 @@ public class Conversation extends TypedData {
     @JsonProperty("conversation_parts")
     private ConversationPartCollection conversationPartCollection;
 
+    @JsonProperty("tags")
+    private TagCollection tagCollection;
+
     @JsonProperty("open")
     private boolean open;
 
@@ -272,6 +275,14 @@ public class Conversation extends TypedData {
         return conversationPartCollection;
     }
 
+    public TagCollection getTagCollection() {
+        if (tagCollection == null) {
+            tagCollection = find(this.getId()).getTagCollection();
+        }
+
+        return tagCollection;
+    }
+
     public boolean getOpen() {
         return open;
     }
@@ -296,6 +307,8 @@ public class Conversation extends TypedData {
             return false;
         if (conversationPartCollection != null ? !conversationPartCollection.equals(that.conversationPartCollection) : that.conversationPartCollection != null)
             return false;
+        if (tagCollection != null ? !tagCollection.equals(that.tagCollection) : that.tagCollection != null)
+            return false;
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
         if (links != null ? !links.equals(that.links) : that.links != null) return false;
         if (!type.equals(that.type)) return false;
@@ -315,6 +328,7 @@ public class Conversation extends TypedData {
         result = 31 * result + (int) (createdAt ^ (createdAt >>> 32));
         result = 31 * result + (int) (updatedAt ^ (updatedAt >>> 32));
         result = 31 * result + (conversationPartCollection != null ? conversationPartCollection.hashCode() : 0);
+        result = 31 * result + (tagCollection != null ? tagCollection.hashCode() : 0);
         result = 31 * result + (open ? 1 : 0);
         result = 31 * result + (read ? 1 : 0);
         result = 31 * result + (links != null ? links.hashCode() : 0);
@@ -332,6 +346,7 @@ public class Conversation extends TypedData {
             ", createdAt=" + createdAt +
             ", updatedAt=" + updatedAt +
             ", conversationPartCollection=" + conversationPartCollection +
+            ", tagCollection=" + tagCollection +
             ", open=" + open +
             ", read=" + read +
             ", links=" + links +

--- a/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
@@ -155,6 +155,51 @@ public class ConversationTest {
         Conversation.find(conversation.getId());
     }
 
+    @Test
+    public void testGetTagsFromConversation() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String json = load("conversation.json");
+        final Conversation conversation = objectMapper.readValue(json, Conversation.class);
+        assertEquals(2, conversation.getTagCollection().getPage().size());
+
+        PowerMockito.verifyStatic(Mockito.never());
+        Conversation.find(conversation.getId());
+    }
+
+    @Test
+    public void testGetTagFromTagCollection() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String conversationsJson = load("conversations.json");
+        final ConversationCollection conversationCollection = objectMapper.readValue(conversationsJson, ConversationCollection.class);
+        final Conversation conversation = conversationCollection.getPage().get(0);
+
+        String conversationJson = load("conversation.json");
+        final Conversation conversationWithTags = objectMapper.readValue(conversationJson, Conversation.class);
+        Mockito.when(Conversation.find(conversation.getId())).thenReturn(conversationWithTags);
+        assertEquals(2, conversation.getTagCollection().getPage().size());
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        Conversation.find(conversation.getId());
+    }
+
+    @Test
+    public void testGetEmptyTagFromTagCollection() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String conversationsJson = load("conversations.json");
+        final ConversationCollection conversationCollection = objectMapper.readValue(conversationsJson, ConversationCollection.class);
+        final Conversation conversation = conversationCollection.getPage().get(0);
+
+        String conversationJson = load("conversation_no_tags.json");
+        final Conversation conversationWithTags= objectMapper.readValue(conversationJson, Conversation.class);
+        Mockito.when(Conversation.find(conversation.getId())).thenReturn(conversationWithTags);
+        assertEquals(0, conversation.getConversationPartCollection().getPage().size());
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        Conversation.find(conversation.getId());
+    }
     private Map<String, String> buildRequestParameters(String html) {
         Map<String, String> params2 = Maps.newHashMap();
         params2.put("type", "admin");

--- a/intercom-java/src/test/resources/conversation.json
+++ b/intercom-java/src/test/resources/conversation.json
@@ -65,6 +65,17 @@
   "read": false,
   "tags": {
     "type": "tag.list",
-    "tags": []
+    "tags": [
+      {
+        "type": "tag",
+        "id": "123",
+        "name": "Tag 1"
+      },
+      {
+        "type": "tag",
+        "id": "456",
+        "name": "Tag 2"
+      }
+    ]
   }
 }

--- a/intercom-java/src/test/resources/conversation_no_tags.json
+++ b/intercom-java/src/test/resources/conversation_no_tags.json
@@ -1,0 +1,37 @@
+{
+  "type": "conversation",
+  "id": "5143511111",
+  "created_at": 1466703132,
+  "updated_at": 1468236397,
+  "conversation_message": {
+    "type": "conversation_message",
+    "id": "33954111",
+    "subject": "",
+    "body": "<p>test</p>",
+    "author": {
+      "type": "lead",
+      "id": "576c1a139d0baad1010011111"
+    },
+    "attachments": [],
+    "url": null
+  },
+  "user": {
+    "type": "user",
+    "id": "576c1a139d0baad1010001111"
+  },
+  "assignee": {
+    "type": "admin",
+    "id": "358111"
+  },
+  "conversation_parts": {
+    "type": "conversation_part.list",
+    "conversation_parts": [],
+    "total_count": 0
+  },
+  "open": true,
+  "read": false,
+  "tags": {
+    "type": "tag.list",
+    "tags": []
+  }
+}


### PR DESCRIPTION
Addressing https://github.com/intercom/intercom-java/issues/128
- uses `getTagCollection` instead of suggested `getTags` for consistency with other existing calls on `TagCollection`

```
intercom-java/src/main/java/io/intercom/api/Company.java:    public TagCollection getTagCollection() {
intercom-java/src/main/java/io/intercom/api/Contact.java:    public TagCollection getTagCollection() {
intercom-java/src/main/java/io/intercom/api/User.java:    public TagCollection getTagCollection() {
```

- Code to retrieved tags modelled after `getConversationPartCollection` https://github.com/intercom/intercom-java/blob/aa17143d531157c544d404bf6ead2ef5cea47bbf/intercom-java/src/main/java/io/intercom/api/Conversation.java#L267-L273


**Sample test run using the new code**

![image](https://user-images.githubusercontent.com/892961/32228613-aece6096-be89-11e7-9630-c9f79a23934e.png)
