### PR TITLE
Adding the possibility to list Events for a given user

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Event.java
+++ b/intercom-java/src/main/java/io/intercom/api/Event.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Maps;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,10 @@ public class Event extends TypedData {
         }
         if (!type.equalsIgnoreCase("user")) {
             throw new IllegalArgumentException("The type parameter must be 'user'.");
+        }
+        List<String> possibleParameterNames = Arrays.asList("user_id", "email", "intercom_user_id");
+        if (!possibleParameterNames.contains(parameterName)) {
+            throw new IllegalArgumentException("The parameterName must be one of:" + possibleParameterNames);
         }
         HashMap<String, String> params = Maps.newHashMap();
         params.put("type", type);

--- a/intercom-java/src/main/java/io/intercom/api/Event.java
+++ b/intercom-java/src/main/java/io/intercom/api/Event.java
@@ -8,7 +8,9 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +50,19 @@ public class Event extends TypedData {
     public static JobItemCollection<Event> listJobErrorFeed(String jobID)
         throws AuthorizationException, ClientException, ServerException, InvalidException, RateLimitException {
         return Job.listJobErrorFeed(jobID, Event.class);
+    }
+
+    public static EventCollection listBy(String type, String parameterName, String parameterValue) {
+        if (type.isEmpty() || parameterName.isEmpty() || parameterValue.isEmpty()) {
+            throw new IllegalArgumentException("The parameters are required.");
+        }
+        if (!type.equalsIgnoreCase("user")) {
+            throw new IllegalArgumentException("The type parameter must be 'user'.");
+        }
+        HashMap<String, String> params = Maps.newHashMap();
+        params.put("type", type);
+        params.put(parameterName, parameterValue);
+        return DataResource.list(params, "events", EventCollection.class);
     }
 
     @VisibleForTesting

--- a/intercom-java/src/main/java/io/intercom/api/EventCollection.java
+++ b/intercom-java/src/main/java/io/intercom/api/EventCollection.java
@@ -1,0 +1,46 @@
+package io.intercom.api;
+
+import java.util.Iterator;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EventCollection  extends TypedDataCollection<Event> implements Iterator<Event> {
+  protected TypedDataCollectionIterator<Event> iterator;
+
+  public EventCollection() {
+    iterator = new TypedDataCollectionIterator<>(this);
+  }
+
+  public EventCollection(List<Event> events) {
+    this();
+    this.page = events;
+  }
+
+  @SuppressWarnings("EmptyMethod")
+  @JsonProperty("events")
+  @Override
+  public List<Event> getPage() {
+    return super.getPage();
+  }
+
+  @Override
+  public EventCollection nextPage() {
+    return fetchNextPage(EventCollection.class);
+  }
+
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  public Event next() {
+    return iterator.next();
+  }
+
+  public void remove() {
+    iterator.remove();
+  }
+}


### PR DESCRIPTION
The use case for adding this is being able to iterate over the recent events triggered by a given user, for reporting purposes. The REST API is already able to do so using a single GET request, given the user ID/e-mail/intercom ID.

I was not able to figure a quick way to write a unit test, without triggering an external HTTP connection (ideally, this would happen with a mock web server).

This addition is corresponding to this section of the API docs: https://developers.intercom.com/v2.0/reference#list-user-events 