### PR TITLE
Remove unnecessary type validation

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -141,9 +141,6 @@ public class Conversation extends TypedData {
     }
 
     static void validateListRequest(Map<String, String> params) {
-        if (!params.containsKey("type")) {
-            throw new InvalidException("a user or admin type must be supplied for a conversation query");
-        }
 
         if (isAdminQuery(params)
                 && !(params.containsKey("admin_id"))) {


### PR DESCRIPTION
Addresses https://github.com/intercom/intercom-java/issues/163

Removes unnecessary type validation 
- as it prevents listing All conversations when using `order` and `sort` parameters without any `type` parameter 
- calling without `type` parameter is accepted by the API   https://developers.intercom.com/reference#section-all-conversations

![image](https://user-images.githubusercontent.com/892961/33944808-27dc5778-e058-11e7-86ff-2f01d29b5143.png)


Will enable calls like this
```
Map<String, String> params = Maps.newHashMap();
params.put("order", "asc"); // or "desc"
params.put("sort", "created_at"); // or "waiting_since" or "updated_at"
ConversationCollection conversations = Conversation.list(params);
```