### PR TITLE
Fixes #162: Add support for updating avatars for Users and Contacts/Leads

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Avatar.java
+++ b/intercom-java/src/main/java/io/intercom/api/Avatar.java
@@ -18,7 +18,7 @@ public class Avatar extends TypedData {
     @JsonProperty("image_url")
     private URI imageURL;
 
-    Avatar() {
+    public Avatar() {
     }
 
     public String getType() {
@@ -27,6 +27,11 @@ public class Avatar extends TypedData {
 
     public URI getImageURL() {
         return imageURL;
+    }
+
+    public Avatar setImageURL(String imageURL) {
+        this.imageURL = URI.create(imageURL);
+        return this;
     }
 
     @Override

--- a/intercom-java/src/main/java/io/intercom/api/Contact.java
+++ b/intercom-java/src/main/java/io/intercom/api/Contact.java
@@ -192,6 +192,7 @@ public class Contact extends TypedData implements Replier {
             contactUpdate.name = c.getName();
             contactUpdate.lastSeenIP = c.getLastSeenIP();
             contactUpdate.customAttributes = c.getCustomAttributes();
+            contactUpdate.avatar = c.getAvatar();
             contactUpdate.lastRequestAt = c.getLastRequestAt();
             contactUpdate.unsubscribedFromEmails = c.getUnsubscribedFromEmails();
             return contactUpdate;
@@ -218,6 +219,9 @@ public class Contact extends TypedData implements Replier {
 
         @JsonProperty("last_seen_ip")
         private String lastSeenIP;
+
+        @JsonProperty("avatar")
+        private Avatar avatar;
 
         @JsonIgnoreProperties(ignoreUnknown = false)
         @JsonProperty("custom_attributes")
@@ -455,6 +459,11 @@ public class Contact extends TypedData implements Replier {
 
     public Avatar getAvatar() {
         return avatar;
+    }
+
+    public Contact setAvatar(Avatar avatar) {
+        this.avatar = avatar;
+        return this;
     }
 
     public long getCreatedAt() {

--- a/intercom-java/src/main/java/io/intercom/api/User.java
+++ b/intercom-java/src/main/java/io/intercom/api/User.java
@@ -113,6 +113,7 @@ public class User extends TypedData implements Replier {
                 userUpdate.companyCollection = buildUserUpdateCompanies(user);
             }
 
+            userUpdate.avatar = user.getAvatar();
             userUpdate.lastRequestAt = user.getLastRequestAt();
             userUpdate.signedUpAt = user.getSignedUpAt();
             userUpdate.unsubscribedFromEmails = user.getUnsubscribedFromEmails();
@@ -156,6 +157,9 @@ public class User extends TypedData implements Replier {
 
         @JsonProperty("last_seen_ip")
         private String lastSeenIp;
+
+        @JsonProperty("avatar")
+        private Avatar avatar;
 
         @JsonIgnoreProperties(ignoreUnknown = false)
         @JsonProperty("custom_attributes")
@@ -266,6 +270,11 @@ public class User extends TypedData implements Replier {
         public Boolean isNewSession() {
             return newSession;
         }
+
+        public Avatar getAvatar() {
+            return avatar;
+        }
+
     }
 
     @JsonProperty("type")
@@ -422,6 +431,11 @@ public class User extends TypedData implements Replier {
 
     public Avatar getAvatar() {
         return avatar;
+    }
+
+    public User setAvatar(Avatar avatar) {
+        this.avatar = avatar;
+        return this;
     }
 
     public long getCreatedAt() {

--- a/intercom-java/src/test/java/io/intercom/api/UserTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/UserTest.java
@@ -29,6 +29,8 @@ public class UserTest {
 
     @Test
     public void TestUserUpdate() throws Exception {
+        final Avatar avatar = new Avatar()
+            .setImageURL("http://example.com/256Wash.jpg");
 
         final long now = System.currentTimeMillis() / 1000;
         final User user = new User()
@@ -41,7 +43,8 @@ public class UserTest {
             .setUnsubscribedFromEmails(true)
             .setUpdateLastRequestAt(true)
             .setNewSession(true)
-            .setUserAgentData("user-agent");
+            .setUserAgentData("user-agent")
+            .setAvatar(avatar);
 
         final User.UserUpdate userUpdate = User.UserUpdate.buildFrom(user);
 
@@ -56,6 +59,7 @@ public class UserTest {
         assertEquals(true, userUpdate.isNewSession());
         assertEquals("user-agent", userUpdate.getLastSeenUserAgent());
         assertEquals(null, userUpdate.getType());
+        assertEquals("http://example.com/256Wash.jpg", userUpdate.getAvatar().getImageURL().toString());
     }
 
     @Test
@@ -179,8 +183,13 @@ public class UserTest {
         assertEquals("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9", user.getUserAgentData());
         assertEquals(1397574667L, user.getLastRequestAt());
         assertEquals(1392731331L, user.getRemoteCreatedAt());
+        assertEquals(1392731331L, user.getSignedUpAt());
         assertEquals(1392734388L, user.getCreatedAt());
         assertEquals(1392734388L, user.getUpdatedAt());
+
+        final Avatar avatar = user.getAvatar();
+        assertEquals("avatar", avatar.getType());
+        assertEquals("http://example.org/128Wash.jpg", avatar.getImageURL().toString());
 
         final SegmentCollection segmentCollection = user.getSegmentCollection();
         assertEquals("segment.list", segmentCollection.getType());

--- a/intercom-java/src/test/resources/user.json
+++ b/intercom-java/src/test/resources/user.json
@@ -6,6 +6,7 @@
     "phone": "+1234567890",
     "name": "Hoban Washburne",
     "remote_created_at": 1392731331,
+    "signed_up_at": 1392731331,
     "updated_at": 1392734388,
     "session_count": 0,
     "last_seen_ip": "1.2.3.4",


### PR DESCRIPTION
Addresses https://github.com/intercom/intercom-java/issues/162 for setting avatar on the user record.

Added feature to contacts/leads as well as tested in REST API and it is supported for them as well