### PR TITLE
Add support for more message attributes

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Attachment.java
+++ b/intercom-java/src/main/java/io/intercom/api/Attachment.java
@@ -1,0 +1,100 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class Attachment extends TypedData {
+
+    @JsonProperty("type")
+    private final String type = "upload";
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("content_type")
+    private String contentType;
+    @JsonProperty("filesize")
+    private long filesize;
+    @JsonProperty("width")
+    private long width;
+    @JsonProperty("height")
+    private long height;
+
+    public Attachment() {
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public long getFilesize() {
+        return filesize;
+    }
+
+    public long getWidth() {
+        return width;
+    }
+
+    public long getHeight() {
+        return height;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Attachment attachment = (Attachment) o;
+
+        if (name != null ? !name.equals(attachment.name) : attachment.name != null) return false;
+        if (url != null ? !url.equals(attachment.url) : attachment.url != null) return false;
+        if (contentType != null ? !contentType.equals(attachment.contentType) : attachment.contentType != null) return false;
+        if (filesize != attachment.filesize) return false;
+        if (height != attachment.height) return false;
+        if (width != attachment.width) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (contentType != null ? contentType.hashCode() : 0);
+        result = 31 * result + (int) (filesize ^ (filesize >>> 32));
+        result = 31 * result + (int) (height ^ (height>>> 32));
+        result = 31 * result + (int) (width ^ (width>>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Avatar{" +
+            "type='" + type + '\'' +
+                ", name='" + name + '\'' +
+                ", url='" + url + '\'' +
+                ", content_type'=" + contentType + '\'' +
+                ", filesize=" + filesize +
+                ", height=" + height +
+                ", widht=" + width +
+            "} " + super.toString();
+    }
+}

--- a/intercom-java/src/main/java/io/intercom/api/ConversationMessage.java
+++ b/intercom-java/src/main/java/io/intercom/api/ConversationMessage.java
@@ -3,6 +3,8 @@ package io.intercom.api;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConversationMessage extends TypedData {
@@ -10,6 +12,9 @@ public class ConversationMessage extends TypedData {
     @SuppressWarnings("FieldCanBeLocal")
     @JsonProperty("type")
     private final String type = "conversation_message";
+
+    @JsonProperty
+    private String id;
 
     @JsonProperty
     private String subject;
@@ -20,11 +25,21 @@ public class ConversationMessage extends TypedData {
     @JsonProperty
     private Author author;
 
+    @JsonProperty
+    private String url;
+
+    @JsonProperty("attachments")
+    private List<Attachment> attachments;
+
     public ConversationMessage() {
     }
 
     public String getType() {
         return type;
+    }
+
+    public String getId() {
+        return id;
     }
 
     public String getSubject() {
@@ -39,11 +54,23 @@ public class ConversationMessage extends TypedData {
         return author;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
+    public List<Attachment> getAttachments() {
+        return attachments;
+    }
+
     @Override
     public int hashCode() {
         int result = subject != null ? subject.hashCode() : 0;
         result = 31 * result + (body != null ? body.hashCode() : 0);
         result = 31 * result + (author != null ? author.hashCode() : 0);
+        result = 31 * result + (id != null ? id.hashCode() : 0);
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        result = 31 * result + (attachments != null ? attachments.hashCode() : 0);
+
         return result;
     }
 
@@ -58,6 +85,9 @@ public class ConversationMessage extends TypedData {
         if (body != null ? !body.equals(that.body) : that.body != null) return false;
         //noinspection RedundantIfStatement
         if (subject != null ? !subject.equals(that.subject) : that.subject != null) return false;
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+        if (attachments != null ? !attachments.equals(that.attachments) : that.attachments != null) return false;
 
         return true;
     }
@@ -66,9 +96,12 @@ public class ConversationMessage extends TypedData {
     public String toString() {
         return "ConversationMessage{" +
             "type='" + type + '\'' +
+            ", id='" + id + '\'' +
             ", subject='" + subject + '\'' +
             ", body='" + body + '\'' +
             ", author=" + author +
+            ", url=" + url +
+            ", attachments=" + attachments +
             "} " + super.toString();
     }
 }

--- a/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
@@ -110,6 +110,68 @@ public class ConversationTest {
     }
 
     @Test
+    public void testGetConversationMessageDetailsFromConversation() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String json = load("conversation.json");
+        final Conversation conversation = objectMapper.readValue(json, Conversation.class);
+        final ConversationMessage conversationMessage = conversation.getConversationMessage();
+
+        assertEquals("33954111", conversationMessage.getId());
+        assertEquals("<p>test</p>", conversationMessage.getBody());
+        assertEquals("Email subject", conversationMessage.getSubject());
+        assertEquals("https://intercom.com/", conversationMessage.getUrl());
+
+        assertEquals("lead", conversationMessage.getAuthor().getType());
+        assertEquals("576c1a139d0baad1010011111", conversationMessage.getAuthor().getId());
+
+        assertEquals(2, conversationMessage.getAttachments().size());
+
+        final Attachment firstAttachment = conversationMessage.getAttachments().get(0);
+        final Attachment lastAttachment = conversationMessage.getAttachments().get(1);
+        assertEquals("upload", firstAttachment.getType());
+        assertEquals("123.csv", firstAttachment.getName());
+        assertEquals("https://downloads.intercomcdn.com/123.csv", firstAttachment.getUrl());
+        assertEquals("text/csv", firstAttachment.getContentType());
+        assertEquals(147, firstAttachment.getFilesize());
+        assertEquals(0, firstAttachment.getWidth());
+        assertEquals(0, firstAttachment.getHeight());
+
+        assertEquals("upload", lastAttachment.getType());
+        assertEquals("abc.txt", lastAttachment.getName());
+        assertEquals("https://downloads.intercomcdn.com/txt", lastAttachment.getUrl());
+        assertEquals("text/csv", lastAttachment.getContentType());
+        assertEquals(100, lastAttachment.getFilesize());
+        assertEquals(1, lastAttachment.getWidth());
+        assertEquals(2, lastAttachment.getHeight());
+
+        PowerMockito.verifyStatic(Mockito.never());
+        Conversation.find(conversation.getId());
+    }
+
+    @Test
+    public void testGetConversationMessageDetailsFromConversationNoAttachments() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String json = load("conversation_no_attachments.json");
+        final Conversation conversation = objectMapper.readValue(json, Conversation.class);
+        final ConversationMessage conversationMessage = conversation.getConversationMessage();
+
+        assertEquals("33954111", conversationMessage.getId());
+        assertEquals("<p>test</p>", conversationMessage.getBody());
+        assertEquals("Email subject", conversationMessage.getSubject());
+        assertEquals("https://intercom.com/", conversationMessage.getUrl());
+
+        assertEquals("lead", conversationMessage.getAuthor().getType());
+        assertEquals("576c1a139d0baad1010011111", conversationMessage.getAuthor().getId());
+
+        assertEquals(0, conversationMessage.getAttachments().size());
+
+        PowerMockito.verifyStatic(Mockito.never());
+        Conversation.find(conversation.getId());
+    }
+
+    @Test
     public void testGetConversationsPartFromConversation() throws IOException {
         PowerMockito.mockStatic(Conversation.class);
 

--- a/intercom-java/src/test/resources/conversation_no_attachments.json
+++ b/intercom-java/src/test/resources/conversation_no_attachments.json
@@ -13,23 +13,7 @@
       "type": "lead",
       "id": "576c1a139d0baad1010011111"
     },
-    "attachments": [{
-      "type": "upload",
-      "name": "123.csv",
-      "url": "https://downloads.intercomcdn.com/123.csv",
-      "content_type": "text/csv",
-      "filesize": 147,
-      "width": null,
-      "height": null
-    },{
-      "type": "upload",
-      "name": "abc.txt",
-      "url": "https://downloads.intercomcdn.com/txt",
-      "content_type": "text/csv",
-      "filesize": 100,
-      "width": 1,
-      "height": 2
-    }],
+    "attachments": [],
     "url": "https://intercom.com/"
   },
   "user": {


### PR DESCRIPTION
Addresses: https://github.com/intercom/intercom-java/issues/176

When reading a conversation there are conversation_message details that are not currently extracted such as `id`, `url` and `attachments`

This PR adds support for these attributes

![image](https://user-images.githubusercontent.com/892961/35433600-05596c02-02bf-11e8-91b7-91770a656ebf.png)
