### PR TITLE
Fix scroll endpoint with a proper URI value

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/DataResource.java
+++ b/intercom-java/src/main/java/io/intercom/api/DataResource.java
@@ -71,7 +71,7 @@ abstract class DataResource {
         if (!Strings.isNullOrEmpty(scrollParam)) {
             params.put("scroll_param", scrollParam);
         }
-        final HttpClient resource = new HttpClient(UriBuilder.newBuilder().path(collectionPath + "/scroll").query(params).build());
+        final HttpClient resource = new HttpClient(UriBuilder.newBuilder().path(collectionPath).path("scroll").query(params).build());
         return resource.get(c);
     }
 


### PR DESCRIPTION
Fixes https://github.com/intercom/intercom-java/issues/185

We previously specified `/scroll` https://github.com/intercom/intercom-java/blob/283c8e8f9d903ff5ebd4165b95afe26123e33472/intercom-java/src/main/java/io/intercom/api/DataResource.java#L74 which was getting encoded to `%2Fscroll` due to 
https://github.com/intercom/intercom-java/blob/f50c869194eac5d4fc047e08634b99c14334e88b/intercom-java/src/main/java/io/intercom/api/UriBuilder.java#L70

Looks like a recent server side change has broken the previous incorrect code so this PR enables proper syntax for the scroll endpoint 


Tested and it works as expected now for Users, Contacts and Companies scroll endpoint (sample test code below for each)

**Users**
```
ScrollableUserCollection usersScroll = User.scroll();
List<User> users = usersScroll.getPage();

for(int i = 0; i < users.size(); i++){
    System.out.println(i + "." + users.get(i).getId()) ;
}
System.out.println("=================") ;
usersScroll = usersScroll.scroll();
users = usersScroll.getPage();
for(int i = 0; i < users.size(); i++){
    System.out.println(i + "." + users.get(i).getId()) ;
}
```

**Contacts**
```
ScrollableContactCollection contactScroll = Contact.scroll();
List<Contact> contacts = contactScroll.getPage();

for(int i = 0; i < contacts.size(); i++){
    System.out.println(i + "." + contacts.get(i).getID()) ;
}
System.out.println("=================") ;
contactScroll = contactScroll.scroll();
contacts = contactScroll.getPage();
for(int i = 0; i < contacts.size(); i++){
    System.out.println(i + "." + contacts.get(i).getID()) ;
}
```

**Companies**
```
ScrollableCompanyCollection companyScroll = Company.scroll();
List<Company> companies = companyScroll.getPage();

for(int i = 0; i < companies.size(); i++){
    System.out.println(i + "." + companies.get(i).getId()) ;
}
System.out.println("=================") ;
companyScroll = companyScroll.scroll();
companies = companyScroll.getPage();
for(int i = 0; i < companies.size(); i++){
    System.out.println(i + "." + companies.get(i).getId()) ;
}
```