### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   //noinspection GroovyAssignabilityCheck
   dependencies {
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
-    classpath 'org.ajoberstar:gradle-git:0.10.0'
+    classpath 'org.ajoberstar:grgit:1.9.3'
   }
 }
 
@@ -24,7 +24,7 @@ subprojects {
     //noinspection GroovyAssignabilityCheck
     dependencies {
       classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
-      classpath 'org.ajoberstar:gradle-git:0.10.0'
+      classpath 'org.ajoberstar:grgit:1.9.3'
     }
   }
 


### PR DESCRIPTION
Updating this dependency looks to fix the previous publishing issue due to existing tags.
Gradle-git is no longer in development so moving to new core library which is  https://github.com/ajoberstar/gradle-git

Using older version of this dependency 
- due to the fact that it requires Java 8 / 1.8 https://github.com/ajoberstar/grgit/releases/tag/2.0.0 
- while our `sourceCompatibility` and `targetCompatibility` is set to 1.7 i.e. Java 7 https://github.com/intercom/intercom-java/blob/a0bc709208d0398dc5e119cebdaa7dab43f0dbab/build.gradle#L41-L42

