### PR TITLE
Prioritise user_id over email in user tagging (Fixes: #197)

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Tag.java
+++ b/intercom-java/src/main/java/io/intercom/api/Tag.java
@@ -83,11 +83,11 @@ public class Tag extends TypedData {
             if (!Strings.isNullOrEmpty(id)) {
                 userMap.put("id", id);
                 usersLite.add(userMap);
-            } else if (!Strings.isNullOrEmpty(email)) {
-                userMap.put("email", email);
-                usersLite.add(userMap);
             } else if (!Strings.isNullOrEmpty(userId)) {
                 userMap.put("user_id", userId);
+                usersLite.add(userMap);
+            } else if (!Strings.isNullOrEmpty(email)) {
+                userMap.put("email", email);
                 usersLite.add(userMap);
             } else {
                 logger.warn("no identifiers found for user tag target, skipping [" + tag + "] [" + user.toString() + "]");


### PR DESCRIPTION
Fix for https://github.com/intercom/intercom-java/issues/197 


- Currently library fails tagging users via `Tag.tag(tag, user);`
   -  if the user object has both user_id and email
   - and the email is used on multiple records
- Due to code below where we prioritise email over user_id 
https://github.com/intercom/intercom-java/blob/f50c869194eac5d4fc047e08634b99c14334e88b/intercom-java/src/main/java/io/intercom/api/Tag.java#L83-L94

Current library would fail on this
```
        User user = new User().setUserId(USER_ID).setEmail(EMAIL_THAT_IS_ON_MULTIPLE_RECORDS);
        Tag tag = new Tag().setName("test-tag");
        tag = Tag.create(tag);
        Tag.tag(tag, user);
```

![image](https://user-images.githubusercontent.com/892961/40814796-0e629c2e-6575-11e8-8b8f-13009cd757d7.png)

Essentially the code above would create this API request
```
{
  "name": "test-tag",
  "users":[
    {
      "email" : EMAIL_THAT_IS_ON_MULTIPLE_RECORDS
    }
   ]
}
```

Instead of 
```
{
  "name": "test-tag",
  "users":[
    {
      "user_id" : USER_ID
    }
   ]
}
```

Reshuffling so user_id has precendence over this it will fix it