### PR TITLE
Add contact/lead deletion by ID and User ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ contact = Contact.findByUserID("e1a7d875-d83a-46f7-86f4-73be98a98584");
 contact.setName("Stitch Hessian");
 Contact updated = Contact.update(contact);
 
+// Update a contact by ID
+Contact contact = new Contact().setID("541a144b201ebf2ec5000002").setName("Stitch Hessian");
+Contact updated = Contact.update(contact);
+
+// Update a contact by User ID
+Contact contact = new Contact().setUserID("e1a7d875-d83a-46f7-86f4-73be98a98584").setName("Stitch Hessian");
+Contact updated = Contact.update(contact);
+
 // Read a contact list by email
 ContactCollection contacts = Contact.listByEmail("jubal@serenity.io");
 while(contacts.hasNext()) {
@@ -216,9 +224,20 @@ ScrollableContactCollection contactsScroll = Contact.scroll();
 List<Contact> contacts = contactsScroll.getPage();
 contactsScroll = contactsScroll.scroll();
 
+// List contacts (sorting)
+Map<String, String> params = Maps.newHashMap();
+params.put("sort", "created_at");
+params.put("order", "asc");
+ContactCollection contacts = Contact.list(params);
 
 // Remove a contact
 Contact.delete(contact);
+
+// Remove a contact by id
+Contact.delete(contact.getID());
+
+// Remove a contact by user_id
+Contact.deleteByUserID(contact.getUserID());
 
 // Convert a contact
 User converted = Contact.convert(contact, user);

--- a/intercom-java/src/main/java/io/intercom/api/Contact.java
+++ b/intercom-java/src/main/java/io/intercom/api/Contact.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import java.net.URI;
@@ -66,7 +67,27 @@ public class Contact extends TypedData implements Replier {
 
     public static Contact delete(Contact c)
             throws AuthorizationException, ClientException, ServerException, InvalidException, RateLimitException {
-        return DataResource.delete(c.getID(), "contacts", Contact.class);
+        if(!Strings.isNullOrEmpty(c.getID())) {
+            return delete(c.getID());
+        }
+        else if(!Strings.isNullOrEmpty(c.getUserID())) {
+            return deleteByUserID(c.getUserID());
+        }
+        else {
+            throw new InvalidException("to delete a contact you must provide a id or user_id value");
+        }
+    }
+
+    public static Contact delete(String id)
+            throws AuthorizationException, ClientException, ServerException, InvalidException, RateLimitException {
+        return DataResource.delete(id, "contacts", Contact.class);
+    }
+
+    public static Contact deleteByUserID(String user_id)
+            throws AuthorizationException, ClientException, ServerException, InvalidException, RateLimitException {
+        Map<String, String> params = new HashMap<String,String>();
+        params.put("user_id", user_id);
+        return DataResource.delete(params, "contacts", Contact.class);
     }
 
     public static User convert(Contact c, User u)
@@ -416,8 +437,7 @@ public class Contact extends TypedData implements Replier {
         return id;
     }
 
-    @VisibleForTesting
-    Contact setID(String id) {
+    public Contact setID(String id) {
         this.id = id;
         return this;
     }
@@ -455,6 +475,11 @@ public class Contact extends TypedData implements Replier {
 
     public String getUserID() {
         return userID;
+    }
+
+    public Contact setUserID(String userID) {
+        this.userID = userID;
+        return this;
     }
 
     public Avatar getAvatar() {


### PR DESCRIPTION
- Allow direct contact/lead deletion by ID / user_id value
- Make existing .delete(contact) smarter
   - if no `id` but has `user_id` do deletion by user_id
   - throw an exception if no identifiers
- Adding the new `setID` and `setUserID` functions coincidentally allows better updating of contacts as well
   - previously you had to find a contact, make changes to that object and update that contact
   - now you can create a contact object and update directly simplifying and reducing API calls