### PR TITLE
Remove company deletion endpoint as it doesn't exist in the API

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Company.java
+++ b/intercom-java/src/main/java/io/intercom/api/Company.java
@@ -49,10 +49,6 @@ public class Company extends TypedData {
         return DataResource.update(entity, "companies", Company.class);
     }
 
-    public static Company delete(String id) throws InvalidException, AuthorizationException {
-        return DataResource.delete(id, "companies", Company.class);
-    }
-
     public static CompanyCollection list(Map<String, String> params) throws InvalidException, AuthorizationException {
         return DataResource.list(params, "companies", CompanyCollection.class);
     }


### PR DESCRIPTION
As detailed in https://github.com/intercom/intercom-java/issues/207 we currently reference a company deletion endpoint in the SDK code but it doesn't exist in the actual Intercom API.

This PR removes the corresponding code