### PR TITLE
Remove API Key references

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/HttpClient.java
+++ b/intercom-java/src/main/java/io/intercom/api/HttpClient.java
@@ -236,14 +236,7 @@ class HttpClient {
     }
 
     private Map<String, String> createAuthorizationHeaders() {
-        switch (Intercom.getAuthKeyType()) {
-            case API_KEY:
-                headers.put("Authorization", "Basic " + generateAuthString(Intercom.getAppID(),Intercom.getApiKey()));
-                break;
-            case TOKEN:
-                headers.put("Authorization", "Basic " + generateAuthString(Intercom.getToken(),""));
-                break;
-        }
+        headers.put("Authorization", "Basic " + generateAuthString(Intercom.getToken(),""));
         return headers;
     }
 

--- a/intercom-java/src/main/java/io/intercom/api/Intercom.java
+++ b/intercom-java/src/main/java/io/intercom/api/Intercom.java
@@ -5,10 +5,7 @@ import java.net.URI;
 public class Intercom {
 
     static class Context {
-        private volatile AuthKeyType authKeyType = AuthKeyType.API_KEY;
-        private volatile String apiKey;
         private volatile String token;
-        private volatile String appID;
         private volatile int connectionTimeout = 3 * 1000;
         private volatile int requestTimeout = 60 * 1000;
         private volatile boolean requestUsingCaches = false;
@@ -19,11 +16,6 @@ public class Intercom {
     private static volatile boolean useThreadLocal = false;
 
     private static volatile URI apiBaseURI = API_BASE_URI;
-
-    enum AuthKeyType {
-        API_KEY,
-        TOKEN
-    }
 
     private static final String VERSION = "2.7.0";
 
@@ -80,30 +72,9 @@ public class Intercom {
         Intercom.httpConnectorSupplier = supplier;
     }
 
-    public static String getAppID() {
-        return getContext().appID;
-    }
-
-    public static void setAppID(String appID) {
-        getContext().appID = appID;
-    }
-
     public static void setToken(String token) {
         Context context = getContext();
-        context.authKeyType = AuthKeyType.TOKEN;
         context.token = token;
-        context.apiKey = null;
-    }
-
-    public static String getApiKey() {
-        return getContext().apiKey;
-    }
-
-    public static void setApiKey(String apiKey) {
-        Context context = getContext();
-        context.authKeyType = AuthKeyType.API_KEY;
-        context.apiKey = apiKey;
-        context.token = null;
     }
 
     public static URI getApiBaseURI() {
@@ -112,10 +83,6 @@ public class Intercom {
 
     public static void setApiBaseURI(URI apiBaseURI) {
         Intercom.apiBaseURI = apiBaseURI;
-    }
-
-    static AuthKeyType getAuthKeyType() {
-        return getContext().authKeyType;
     }
 
     public static String getToken() {

--- a/intercom-java/src/test/java/io/intercom/api/IntercomTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/IntercomTest.java
@@ -29,29 +29,15 @@ public class IntercomTest {
     }
 
     @Test
-    public void testApiKey() {
-        Intercom.setApiKey("k1");
-        assertEquals("k1", Intercom.getApiKey());
-        assertEquals(Intercom.AuthKeyType.API_KEY, Intercom.getAuthKeyType());
-        assertNull(Intercom.getToken());
-    }
-
-    @Test
     public void testToken() {
         Intercom.setToken("t1");
         assertEquals("t1", Intercom.getToken());
-        assertEquals(Intercom.AuthKeyType.TOKEN, Intercom.getAuthKeyType());
-        assertNull(Intercom.getApiKey());
     }
 
     @Test
     public void testStaticContext() throws Exception {
-        Intercom.setApiKey("k1");
-        assertEquals("k1", Intercom.getApiKey());
-        assertNull(Intercom.getToken());
-        assertEquals(Intercom.AuthKeyType.API_KEY, Intercom.getAuthKeyType());
-        Intercom.setAppID("app1");
-        assertEquals("app1", Intercom.getAppID());
+        Intercom.setToken("t1");
+        assertEquals("t1", Intercom.getToken());
         Intercom.setConnectionTimeout(98765);
         assertEquals(98765, Intercom.getConnectionTimeout());
         Intercom.setRequestTimeout(12345);
@@ -66,15 +52,11 @@ public class IntercomTest {
         tt1.waitUntilComplete();
         tt2.waitUntilComplete();
 
-        assertEquals(Intercom.getApiKey(), tt1.apiKey);
-        assertEquals(Intercom.getAuthKeyType(), tt1.authKeyType);
         assertEquals(Intercom.getToken(), tt1.token);
         assertEquals(Intercom.getConnectionTimeout(), tt1.connectionTimeout);
         assertEquals(Intercom.getRequestTimeout(), tt1.requestTimeout);
         assertEquals(Intercom.isRequestUsingCaches(), tt1.requestUsingCaches);
 
-        assertEquals(Intercom.getApiKey(), tt2.apiKey);
-        assertEquals(Intercom.getAuthKeyType(), tt2.authKeyType);
         assertEquals(Intercom.getToken(), tt2.token);
         assertEquals(Intercom.getConnectionTimeout(), tt2.connectionTimeout);
         assertEquals(Intercom.getRequestTimeout(), tt2.requestTimeout);
@@ -93,15 +75,11 @@ public class IntercomTest {
         tt2.waitUntilComplete();
 
         assertEquals(tt1.localToken, tt1.token);
-        assertNull(tt1.apiKey);
-        assertEquals(Intercom.AuthKeyType.TOKEN, tt1.authKeyType);
         assertEquals(tt1.localConnectionTimeout, tt1.connectionTimeout);
         assertEquals(tt1.localRequestTimeout, tt1.requestTimeout);
         assertEquals(tt1.localRequestUsingCaches, tt1.requestUsingCaches);
 
-        assertEquals(tt2.localApiKey, tt2.apiKey);
-        assertNull(tt2.token);
-        assertEquals(Intercom.AuthKeyType.API_KEY, tt2.authKeyType);
+        assertEquals(tt2.localToken, tt2.token);
         assertEquals(tt2.localConnectionTimeout, tt2.connectionTimeout);
         assertEquals(tt2.localRequestTimeout, tt2.requestTimeout);
         assertEquals(tt2.localRequestUsingCaches, tt2.requestUsingCaches);
@@ -111,33 +89,32 @@ public class IntercomTest {
     public void testClearThreadLocalContexts() throws Exception {
         Intercom.setUseThreadLocal(true);
 
-        Intercom.setApiKey("testKey");
-        assertEquals("testKey", Intercom.getApiKey());
+        Intercom.setToken("testToken");
+        assertEquals("testToken", Intercom.getToken());
 
         Intercom.clearThreadLocalContexts();
-        assertNull(Intercom.getApiKey());
+        assertNull(Intercom.getToken());
 
-        Intercom.setApiKey("testKey2");
-        assertEquals("testKey2", Intercom.getApiKey());
+        Intercom.setToken("testToken2");
+        assertEquals("testToken2", Intercom.getToken());
     }
 
     @Test
     public void testClearThreadLocalContext() throws Exception {
         Intercom.setUseThreadLocal(true);
 
-        Intercom.setApiKey("testKey");
-        assertEquals("testKey", Intercom.getApiKey());
+        Intercom.setToken("testToken");
+        assertEquals("testToken", Intercom.getToken());
 
         Intercom.clearThreadLocalContext();
-        assertNull(Intercom.getApiKey());
+        assertNull(Intercom.getToken());
 
-        Intercom.setApiKey("testKey2");
-        assertEquals("testKey2", Intercom.getApiKey());
+        Intercom.setToken("testToken2");
+        assertEquals("testToken2", Intercom.getToken());
     }
 
     class ThreadTester implements Runnable {
-        String apiKey, appId, token;
-        Intercom.AuthKeyType authKeyType;
+        String token;
         int connectionTimeout = -1;
         int requestTimeout = -1;
         Boolean requestUsingCaches;
@@ -145,10 +122,7 @@ public class IntercomTest {
 
         @Override
         public void run() {
-            apiKey = Intercom.getApiKey();
-            authKeyType = Intercom.getAuthKeyType();
             token = Intercom.getToken();
-            appId = Intercom.getAppID();
             connectionTimeout = Intercom.getConnectionTimeout();
             requestTimeout = Intercom.getRequestTimeout();
             requestUsingCaches = Intercom.isRequestUsingCaches();
@@ -170,7 +144,6 @@ public class IntercomTest {
     class ThreadLocalTester1 extends ThreadTester {
         final Random rnd = new Random();
         final String localToken = "tx";
-        final String localAppId = "appx";
         final int localConnectionTimeout = rnd.nextInt();
         final int localRequestTimeout = rnd.nextInt();
         final boolean localRequestUsingCaches = rnd.nextBoolean();
@@ -179,7 +152,6 @@ public class IntercomTest {
         public void run() {
             Intercom.clearThreadLocalContext();
             Intercom.setToken(localToken);
-            Intercom.setAppID(localAppId);
             Intercom.setConnectionTimeout(localConnectionTimeout);
             Intercom.setRequestTimeout(localRequestTimeout);
             Intercom.setRequestUsingCaches(localRequestUsingCaches);
@@ -189,8 +161,7 @@ public class IntercomTest {
 
     class ThreadLocalTester2 extends ThreadTester {
         final Random rnd = new Random();
-        final String localApiKey = "api";
-        final String localAppId = "appId";
+        final String localToken = "t2";
         final int localConnectionTimeout = rnd.nextInt();
         final int localRequestTimeout = rnd.nextInt();
         final boolean localRequestUsingCaches = rnd.nextBoolean();
@@ -198,8 +169,7 @@ public class IntercomTest {
         @Override
         public void run() {
             Intercom.clearThreadLocalContext();
-            Intercom.setApiKey(localApiKey);
-            Intercom.setAppID(localAppId);
+            Intercom.setToken(localToken);
             Intercom.setConnectionTimeout(localConnectionTimeout);
             Intercom.setRequestTimeout(localRequestTimeout);
             Intercom.setRequestUsingCaches(localRequestUsingCaches);


### PR DESCRIPTION
#### Why?
- Addresses https://github.com/intercom/intercom-java/issues/226
- We are no longer utilising API keys in our API itself (they have been replaced by tokens)

#### How?
- Removing references to API keys 
- Change API key to tokens where needed
