### PR TITLE
Remove invalid company session setter

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Company.java
+++ b/intercom-java/src/main/java/io/intercom/api/Company.java
@@ -37,7 +37,6 @@ public class Company extends TypedData {
         final CompanyWithStringPlan entity = new CompanyWithStringPlan();
         entity.setCompanyID(company.getCompanyID());
         entity.setName(company.getName());
-        entity.setSessionCount(company.getSessionCount());
         entity.setMonthlySpend(company.getMonthlySpend());
         entity.setRemoteCreatedAt(company.getRemoteCreatedAt());
         entity.setIndustry(company.getIndustry());

--- a/intercom-java/src/main/java/io/intercom/api/CompanyUpdateBuilder.java
+++ b/intercom-java/src/main/java/io/intercom/api/CompanyUpdateBuilder.java
@@ -53,7 +53,6 @@ class CompanyUpdateBuilder {
         updatableCompany.setId(company.getId());
         updatableCompany.setCompanyID(company.getCompanyID());
         updatableCompany.setName(company.getName());
-        updatableCompany.setSessionCount(company.getSessionCount());
         updatableCompany.setMonthlySpend(company.getMonthlySpend());
         updatableCompany.setRemoteCreatedAt(company.getRemoteCreatedAt());
         updatableCompany.setIndustry(company.getIndustry());


### PR DESCRIPTION
#### Why?
- Addresses this issue https://github.com/intercom/intercom-java/issues/231
- Looks like when updating a company or updating a user (after adding a company to the user), we are setting company session value
- Company session is not something modifiable via the API and returns a `Exception in thread "main" io.intercom.api.ClientException: bad 'session_count' parameter` error

#### How?
- Remove references to `setSessionCount` for companies

Test Code that will fail on current code base but will succeed with these new changes
```
        HashMap<String, String> map = Maps.newHashMap();
        map.put("company_id", "1");
        Company company = Company.find(map);
        company.setName("Blue Sun Corporation");
        Company.update(company);

        map = Maps.newHashMap();
        map.put("user_id", "1");
        User user = User.find(map);
        user.addCompany(company);
        User.update(user);
```