### PR TITLE
Add support for `display_as` when finding a conversation

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -37,6 +37,11 @@ public class Conversation extends TypedData {
         return resource.get(Conversation.class);
     }
 
+    public static Conversation find(String id, Map<String, String> params) throws InvalidException, AuthorizationException {
+        final HttpClient resource = new HttpClient(UriBuilder.newBuilder().path("conversations").path(id).query(params).build());
+        return resource.get(Conversation.class);
+    }
+
     public static ConversationCollection list() throws InvalidException, AuthorizationException {
         return DataResource.list(SENTINEL, "conversations", ConversationCollection.class);
     }


### PR DESCRIPTION
- Current code only allows for finding a conversation without any parameters
```
        Conversation c = Conversation.find("18718188522");
```
- Add a new `find` that allows extra parameters 

**Sample usage**
```
        Map<String, String> params = new HashMap<String, String>();
        params.put("display_as", "plaintext");
        Conversation c = Conversation.find("18718188522", params);

```

Docs detailing `display_as` https://developers.intercom.com/intercom-api-reference/reference#get-a-single-conversation
![image](https://user-images.githubusercontent.com/892961/47602379-ae18e880-da10-11e8-9356-d38f80f20c53.png)

