### PR TITLE
Add conversation participants support

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,29 @@ userReply.setBody("Mighty fine shindig");
 userReply.setAttachmentUrls(new String[]{"http://www.example.com/attachment.jpg"}); // optional - list of attachments
 System.out.println(MapperSupport.objectMapper().writeValueAsString(userReply));
 Conversation.reply("66", userReply);
+
+// admin adding participant to conversation
+AdminAddParticipant adminAddParticipant = new AdminAddParticipant();
+adminAddParticipant.setAdminId("248698");
+Participant participant = new Participant();
+participant.setIntercomUserID("5310d8e8598c9a0b24000005");
+// participant.setUserId("2"); // or find by user_id
+// participant.setEmail("fantastic@serenity.io"); // or find by user_id
+adminAddParticipant.setParticipant(participant);
+ParticipantResponse participantResponse = Conversation.addParticipant("19240007891", adminAddParticipant);
+
+// user adding participant to conversation
+UserAddParticipant userAddParticipant = new UserAddParticipant();
+userAddParticipant.setIntercomUserId("575b4dbbd7f9c87f240008c5");
+Participant participant = new Participant();
+participant.setIntercomUserID("5310d8e8598c9a0b24000005");
+// participant.setUserId("2"); // or find by user_id
+// participant.setEmail("fantastic@serenity.io"); // or find by user_id
+userAddParticipant.setParticipant(participant);
+ParticipantResponse participantResponse = Conversation.addParticipant("19240007891", userAddParticipant);
+
+// removing participant from conversation
+ParticipantResponse participantResponse = Conversation.removeParticipant("19240007891", "248698", "564320845c88872b60000012");
 ```
 
 ### Webhooks

--- a/intercom-java/src/main/java/io/intercom/api/AdminAddParticipant.java
+++ b/intercom-java/src/main/java/io/intercom/api/AdminAddParticipant.java
@@ -1,0 +1,45 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class AdminAddParticipant {
+
+    @JsonProperty("admin_id")
+    public String adminId;
+
+    @JsonProperty("customer")
+    private Participant participant;
+
+    public String getAdminId() {
+        return adminId;
+    }
+
+    public AdminAddParticipant setAdminId(String adminId) {
+        this.adminId = adminId;
+        return this;
+    }
+
+    private Participant getParticipant(){
+        return participant;
+    }
+
+    public AdminAddParticipant setParticipant(Participant participant){
+        this.participant = participant;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "AdminAddParticipant{" +
+                "adminId='" + adminId + "\'" +
+                ",participant=" + participant +
+                "} " + super.toString();
+    }
+}

--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -71,6 +71,39 @@ public class Conversation extends TypedData {
             .post(Conversation.class, new AdminReply.AdminStringReply(reply));
     }
 
+    public static ParticipantResponse addParticipant(String id, AdminAddParticipant adminAddParticipant) {
+        final URI uri = UriBuilder.newBuilder()
+                .path("conversations")
+                .path(id)
+                .path("customers")
+                .build();
+        return new HttpClient(uri)
+                .post(ParticipantResponse.class, adminAddParticipant);
+    }
+
+    public static ParticipantResponse addParticipant(String id, UserAddParticipant userAddParticipant) {
+        final URI uri = UriBuilder.newBuilder()
+                .path("conversations")
+                .path(id)
+                .path("customers")
+                .build();
+        return new HttpClient(uri)
+                .post(ParticipantResponse.class, userAddParticipant);
+    }
+
+    public static ParticipantResponse removeParticipant(String id, String admin_id, String participantIntercomId) {
+        Map<String, String> params = new HashMap<String,String>();
+        params.put("admin_id", admin_id);
+        final URI uri = UriBuilder.newBuilder()
+                .path("conversations")
+                .path(id)
+                .path("customers")
+                .path(participantIntercomId)
+                .build();
+        return DataResource.delete(params, uri, ParticipantResponse.class);
+
+    }
+
     public static UserMessage create(UserMessage message) {
         return DataResource.create(message, "messages", UserMessage.class);
     }

--- a/intercom-java/src/main/java/io/intercom/api/Customer.java
+++ b/intercom-java/src/main/java/io/intercom/api/Customer.java
@@ -1,0 +1,69 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Customer extends TypedData {
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("id")
+    private String id;
+
+    public Customer() {
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Customer setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Customer setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Customer customer = (Customer) o;
+
+        if (id != null ? !id.equals(customer.id) : customer.id != null) return false;
+        if (type != null ? !type.equals(customer.type) : customer.type != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Customer{" +
+                "type='" + type + '\'' +
+                ", id='" + id+ '\'' +
+                "} " + super.toString();
+    }
+
+}

--- a/intercom-java/src/main/java/io/intercom/api/DataResource.java
+++ b/intercom-java/src/main/java/io/intercom/api/DataResource.java
@@ -61,6 +61,11 @@ abstract class DataResource {
         return resource.delete(c);
     }
 
+    public static <T> T delete(Map<String, String> params, URI uri, Class<T> c) {
+        final HttpClient resource = new HttpClient(uri);
+        return resource.delete(c, params);
+    }
+
     public static <C> C list(Map<String, String> params, String collectionPath, Class<C> c) {
         final HttpClient resource = new HttpClient(UriBuilder.newBuilder().path(collectionPath).query(params).build());
         return resource.get(c);

--- a/intercom-java/src/main/java/io/intercom/api/HttpClient.java
+++ b/intercom-java/src/main/java/io/intercom/api/HttpClient.java
@@ -90,6 +90,11 @@ class HttpClient {
         return executeHttpMethod("DELETE", null, getJavaType(reqres));
     }
 
+    public <T, E> T delete(Class<T> reqres, E entity) {
+        headers.put("Content-Type", APPLICATION_JSON);
+        return executeHttpMethod("DELETE", entity, getJavaType(reqres));
+    }
+
     public <T, E> T put(Class<T> reqres, E entity) {
         headers.put("Content-Type", APPLICATION_JSON);
         return executeHttpMethod("PUT", (E) entity, getJavaType(reqres));
@@ -178,7 +183,7 @@ class HttpClient {
     }
 
     private boolean shouldSkipResponseEntity(JavaType javaType, HttpURLConnection conn, int responseCode) {
-        return responseCode == 204 || Void.class.equals(javaType.getRawClass()) || "DELETE".equals(conn.getRequestMethod());
+        return responseCode == 204 || Void.class.equals(javaType.getRawClass());
     }
 
     private <T> T readEntity(HttpURLConnection conn, int responseCode, JavaType javaType) throws IOException {

--- a/intercom-java/src/main/java/io/intercom/api/Participant.java
+++ b/intercom-java/src/main/java/io/intercom/api/Participant.java
@@ -1,0 +1,81 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class Participant {
+
+    @JsonProperty("intercom_user_id")
+    private String intercomUserId;
+
+    @JsonProperty("user_id")
+    private String userId;
+
+    @JsonProperty("email")
+    private String email;
+
+    public Participant() {
+    }
+
+    public String getIntercomUserId() {
+        return intercomUserId;
+    }
+
+    public Participant setIntercomUserId(String intercomUserId) {
+        this.intercomUserId = intercomUserId;;
+        return this;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public Participant setUserId(String userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Participant setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = intercomUserId != null ? intercomUserId.hashCode() : 0;
+        result = 31 * result + (userId != null ? userId.hashCode() : 0);
+        result = 31 * result + (email != null ? email.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Participant customer = (Participant) o;
+
+        if (intercomUserId != null ? !intercomUserId.equals(customer.intercomUserId) : customer.intercomUserId != null) return false;
+        if (userId != null ? !userId.equals(customer.userId) : customer.userId != null) return false;
+        if (email != null ? !email.equals(customer.email) : customer.email != null) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Participant{" +
+                ", intercomUserId='" + intercomUserId+ '\'' +
+                ", userId='" + userId+ '\'' +
+                ", email='" + email+ '\'' +
+                "} " + super.toString();
+    }
+}

--- a/intercom-java/src/main/java/io/intercom/api/ParticipantResponse.java
+++ b/intercom-java/src/main/java/io/intercom/api/ParticipantResponse.java
@@ -1,0 +1,24 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ParticipantResponse {
+
+    @JsonProperty("customers")
+    private List<Customer> customers;
+
+    public ParticipantResponse() {
+    }
+
+    public List<Customer> getCustomers(){
+        return customers;
+    }
+}

--- a/intercom-java/src/main/java/io/intercom/api/UserAddParticipant.java
+++ b/intercom-java/src/main/java/io/intercom/api/UserAddParticipant.java
@@ -1,0 +1,71 @@
+package io.intercom.api;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@SuppressWarnings("UnusedDeclaration")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class UserAddParticipant  {
+
+    @JsonProperty("intercom_user_id")
+    public String intercomUserId;
+
+    @JsonProperty("user_id")
+    public String userId;
+
+    @JsonProperty("email")
+    public String email;
+
+    @JsonProperty("customer")
+    private Participant participant;
+
+    public String getIntercomUserId() {
+        return intercomUserId;
+    }
+
+    public UserAddParticipant setIntercomUserId(String intercomUserId) {
+        this.intercomUserId = intercomUserId;
+        return this;
+    }
+
+    public String getUserID() {
+        return userId;
+    }
+
+    public UserAddParticipant setUserID(String userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public UserAddParticipant setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    private Participant getParticipant(){
+        return participant;
+    }
+
+    public UserAddParticipant setParticipant(Participant participant){
+        this.participant = participant;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "UserAddParticipant{" +
+                "intercomUserId='" + intercomUserId + "\'" +
+                "userId='" + userId + "\'" +
+                "email='" + email + "\'" +
+                ",participant=" + participant +
+                "} " + super.toString();
+    }
+}


### PR DESCRIPTION
Adding support for adding and removing of participants from group conversations

- Created a `Participant` class as we're using `Customer` in the response for conversations ratings https://github.com/intercom/intercom-java/pull/235 and also in the return response for the added methods
- Open to feedback on a better approach for this

![image](https://user-images.githubusercontent.com/892961/47603584-92b5d980-da20-11e8-8adb-881a1ceafe1d.png)


**Related Docs:** 
- https://developers.intercom.com/intercom-api-reference/reference#adding-to-group-conversations-as-admin
- https://developers.intercom.com/intercom-api-reference/reference#adding-to-group-conversations-as-customer
- https://developers.intercom.com/intercom-api-reference/reference#deleting-from-group-conversations