### PR TITLE
Allow admin message to contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,10 +485,16 @@ while(notes.hasNext()) {
 ```java
 // send a message to a user
 User user = new User().setId("5310d8e8598c9a0b24000005");
+// Alternatively identify user by user_id or email
+//   User user = new User().setUserId("1")
+//   User user = new User().setEmail("malcolm@serenity.io")
+Contact contact = new Contact().setId("5ab313046e4997e35bc13e7c");
+// Alternatively identify contact by user_id
+//   Contact contact = new Contact().setUserId("697ea3e0-227d-4d70-b776-1652e94f9583");
 Admin admin = new Admin().setId("1");
 AdminMessage adminMessage = new AdminMessage()
     .setAdmin(admin)
-    .setUser(user)
+    .setUser(user) // or .setContact(contact)
     .setSubject("This Land")
     .setBody("Har har har! Mine is an evil laugh!")
     .setMessageType("email")

--- a/intercom-java/src/main/java/io/intercom/api/AdminMessage.java
+++ b/intercom-java/src/main/java/io/intercom/api/AdminMessage.java
@@ -37,7 +37,15 @@ public class AdminMessage extends TypedData {
     private Admin admin;
 
     @JsonProperty("to")
+    private TypedData to(){
+        if(user != null) return user;
+        if(contact != null) return contact;
+        return null;
+    };
+
     private User user;
+
+    private Contact contact;
 
     public AdminMessage() {
     }
@@ -121,6 +129,15 @@ public class AdminMessage extends TypedData {
         return this;
     }
 
+    public Contact getContact() {
+        return contact;
+    }
+
+    public AdminMessage setContact(Contact contact) {
+        this.contact = contact;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -138,6 +155,7 @@ public class AdminMessage extends TypedData {
         if (!type.equals(message.type)) return false;
         //noinspection RedundantIfStatement
         if (user != null ? !user.equals(message.user) : message.user != null) return false;
+        if (contact != null ? !contact.equals(message.contact) : message.contact != null) return false;
 
         return true;
     }
@@ -153,6 +171,7 @@ public class AdminMessage extends TypedData {
         result = 31 * result + (int) (createdAt ^ (createdAt >>> 32));
         result = 31 * result + (admin != null ? admin.hashCode() : 0);
         result = 31 * result + (user != null ? user.hashCode() : 0);
+        result = 31 * result + (contact != null ? contact.hashCode() : 0);
         return result;
     }
 
@@ -167,6 +186,7 @@ public class AdminMessage extends TypedData {
             ", createdAt=" + createdAt +
             ", admin=" + admin +
             ", user=" + user +
+            ", contact=" + contact +
             "} " + super.toString();
     }
 


### PR DESCRIPTION
Allow specifying a contact when creating an admin message to support [sending admin initiated message to contacts](https://developers.intercom.com/intercom-api-reference/reference#admin-initiated-conversation)

![image](https://user-images.githubusercontent.com/892961/47603772-2e484980-da23-11e8-9ded-031793462469.png)
