### PR TITLE
Allow parsing of responses from DELETE requests

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/HttpClient.java
+++ b/intercom-java/src/main/java/io/intercom/api/HttpClient.java
@@ -178,19 +178,18 @@ class HttpClient {
     }
 
     private boolean shouldSkipResponseEntity(JavaType javaType, HttpURLConnection conn, int responseCode) {
-        return responseCode == 204 || Void.class.equals(javaType.getRawClass()) || "DELETE".equals(conn.getRequestMethod());
+        return responseCode == 204 || Void.class.equals(javaType.getRawClass());
     }
 
     private <T> T readEntity(HttpURLConnection conn, int responseCode, JavaType javaType) throws IOException {
         final InputStream entityStream = conn.getInputStream();
         try {
+            final String text = CharStreams.toString(new InputStreamReader(entityStream));
             if (logger.isDebugEnabled()) {
-                final String text = CharStreams.toString(new InputStreamReader(entityStream));
                 logger.debug("api server response status[{}] --\n{}\n-- ", responseCode, text);
-                return objectMapper.readValue(text, javaType);
-            } else {
-                return objectMapper.readValue(entityStream, javaType);
             }
+            if (text.isEmpty()) return null;
+            return objectMapper.readValue(text, javaType);
         } finally {
             IOUtils.closeQuietly(entityStream);
         }


### PR DESCRIPTION
#### Why?
- Current code just returns null for all `DELETE` requests
- In [PR 241](https://github.com/intercom/intercom-java/pull/241) made an attempt to fix it but found that Tag.delete [had an issue](https://github.com/intercom/intercom-java/pull/241#issuecomment-433677341) with the new code

#### How?
- So now we check if `DELETE` response has data if it does proceed to process it as any other normal data
- If there is no data just return null
- Ran through all delete usage and all of them process and parse new code correctly 
```
User.archive(Map<String, String> params)
User.archive(String id)
Contact.delete(String id)
Contact.deleteByUserID(String user_id)
Visitor.delete(Visitor v)
Visitor.delete(String id)
Tag.delete(String id)
Tag.delete(Tag tag) 
Subscription.delete(Subscription subscription)
```