### PR TITLE
make TypedData public

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/TypedData.java
+++ b/intercom-java/src/main/java/io/intercom/api/TypedData.java
@@ -1,9 +1,7 @@
 package io.intercom.api;
 
-public interface TypedData {
-
-    default String getType() {
+public class TypedData {
+    public String getType() {
         throw new UnsupportedOperationException();
     }
-
 }

--- a/intercom-java/src/main/java/io/intercom/api/TypedData.java
+++ b/intercom-java/src/main/java/io/intercom/api/TypedData.java
@@ -1,8 +1,8 @@
 package io.intercom.api;
 
-class TypedData {
+public interface TypedData {
 
-    String getType() {
+    default String getType() {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
#### Why?
Having the TypedData packed private makes it very hard to extend the existing library with custom functionality. 
While scala users may do something like `type WithDataType = {def getType() : String}` and follow it with ` def apply[T <: WithDataType](method: String, data: T` such approach works somewhat slow, as runtime reflective checks are required.


#### How?
make it interface and public. 
