### PR TITLE
Add support for ConversationPart.getAttachments()

### DIFF
--- a/intercom-java/src/main/java/io/intercom/api/Conversation.java
+++ b/intercom-java/src/main/java/io/intercom/api/Conversation.java
@@ -230,6 +230,9 @@ public class Conversation extends TypedData {
     @JsonProperty("updated_at")
     private long updatedAt;
 
+    @JsonProperty("customers")
+    private List<Customer> customers;
+
     @JsonProperty("waiting_since")
     private long waitingSince;
 
@@ -313,6 +316,8 @@ public class Conversation extends TypedData {
     public long getUpdatedAt() {
         return updatedAt;
     }
+
+    public List<Customer> getCustomers() { return customers; }
 
     public long getWaitingSince() {
         return waitingSince;

--- a/intercom-java/src/main/java/io/intercom/api/ConversationPart.java
+++ b/intercom-java/src/main/java/io/intercom/api/ConversationPart.java
@@ -3,6 +3,8 @@ package io.intercom.api;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 @SuppressWarnings("UnusedDeclaration")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConversationPart extends TypedData {
@@ -24,6 +26,9 @@ public class ConversationPart extends TypedData {
 
     @JsonProperty("assigned_to")
     private Admin assignedTo;
+
+    @JsonProperty("attachments")
+    private List<Attachment> attachments;
 
     @JsonProperty("created_at")
     private long createdAt;
@@ -60,6 +65,8 @@ public class ConversationPart extends TypedData {
     public Admin getAssignedTo() {
         return assignedTo;
     }
+
+    public List<Attachment> getAttachments() { return attachments; }
 
     public long getCreatedAt() {
         return createdAt;

--- a/intercom-java/src/test/java/io/intercom/api/ConversationPartTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/ConversationPartTest.java
@@ -1,0 +1,76 @@
+package io.intercom.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.List;
+
+import static io.intercom.api.TestSupport.load;
+
+import static org.junit.Assert.*;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { Conversation.class })
+public class ConversationPartTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public static void beforeClass() {
+        objectMapper = MapperSupport.objectMapper();
+    }
+
+    @Test
+    public void testGetConversationPartDetailsFromConversationNoAttachments() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String json = load("conversation_no_attachments.json");
+        final Conversation conversation = objectMapper.readValue(json, Conversation.class);
+        final List<ConversationPart> parts = conversation.getConversationPartCollection().getPage();
+
+        assertEquals(2, parts.size());
+
+        final ConversationPart part = parts.get(0);
+
+        assertEquals("142533411", part.getId());
+        assertEquals("comment", part.getPartType());
+        assertEquals("<p>dm-9187dba8-fb3b-cb99-da05-37a932d3d678</p>", part.getBody());
+        assertEquals(1468031160, part.getCreatedAt());
+        assertEquals(1468031160, part.getUpdatedAt());
+        assertEquals(1468031160, part.getNotifiedAt());
+        assertEquals(null, part.getAssignedTo());
+        assertEquals("576c1a139d0baad1010001111", part.getAuthor().getId());
+        assertEquals("user", part.getAuthor().getType());
+        assertEquals(0, part.getAttachments().size());
+
+        PowerMockito.verifyStatic(Mockito.never());
+        Conversation.find(conversation.getId());
+    }
+
+    @Test
+    public void testGetAttachmentsFromConversationPart() throws IOException {
+        String json = load("conversation_part_with_attachments.json");
+        final ConversationPart part = objectMapper.readValue(json, ConversationPart.class);
+
+        final List<Attachment> attachments = part.getAttachments();
+        assertEquals(2, attachments.size());
+
+        final Attachment attachment = attachments.get(0);
+
+        assertEquals("upload", attachment.getType());
+        assertEquals("Attachment.pdf", attachment.getName());
+        assertEquals("https://api.example.com/uploads/111222333", attachment.getUrl());
+        assertEquals("application/pdf", attachment.getContentType());
+        assertEquals(8388608, attachment.getFilesize());
+        assertEquals(1024, attachment.getWidth());
+        assertEquals(8192, attachment.getHeight());
+    }
+}

--- a/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
+++ b/intercom-java/src/test/java/io/intercom/api/ConversationTest.java
@@ -262,6 +262,19 @@ public class ConversationTest {
         PowerMockito.verifyStatic(Mockito.times(1));
         Conversation.find(conversation.getId());
     }
+
+    @Test
+    public void testGetCustomersFromConversation() throws IOException {
+        PowerMockito.mockStatic(Conversation.class);
+
+        String json = load("conversation.json");
+        final Conversation conversation = objectMapper.readValue(json, Conversation.class);
+        assertEquals(2, conversation.getCustomers().size());
+
+        PowerMockito.verifyStatic(Mockito.never());
+        Conversation.find(conversation.getId());
+    }
+
     private Map<String, String> buildRequestParameters(String html) {
         Map<String, String> params2 = Maps.newHashMap();
         params2.put("type", "admin");

--- a/intercom-java/src/test/resources/conversation.json
+++ b/intercom-java/src/test/resources/conversation.json
@@ -78,6 +78,16 @@
     ],
     "total_count": 2
   },
+  "customers": [
+    {
+      "id": "cce765411111",
+      "type": "lead"
+    },
+    {
+      "id": "ee88370001110101",
+      "type": "user"
+    }
+  ],
   "open": true,
   "read": false,
   "tags": {

--- a/intercom-java/src/test/resources/conversation_part_with_attachments.json
+++ b/intercom-java/src/test/resources/conversation_part_with_attachments.json
@@ -1,0 +1,35 @@
+{
+  "type": "conversation_part",
+  "id": "142533411",
+  "part_type": "comment",
+  "body": "<p>dm-9187dba8-fb3b-cb99-da05-37a932d3d678</p>",
+  "created_at": 1468031160,
+  "updated_at": 1468031160,
+  "notified_at": 1468031160,
+  "assigned_to": null,
+  "author": {
+    "type": "user",
+    "id": "576c1a139d0baad1010001111"
+  },
+  "attachments": [
+    {
+      "type": "upload",
+      "name": "Attachment.pdf",
+      "url": "https://api.example.com/uploads/111222333",
+      "content_type": "application/pdf",
+      "filesize": 8388608,
+      "width": 1024,
+      "height": 8192
+    },
+    {
+      "type": "upload",
+      "name": "Attachment.txt",
+      "url": "https://api.example.com/uploads/222333444",
+      "content_type": "text/plain",
+      "filesize": 16000,
+      "width": 40,
+      "height": 400
+    }
+  ],
+  "external_id": null
+}


### PR DESCRIPTION
This adds bindings for:

- `conversation_part.attachments`
- `conversation.customers`

Also adds a couple tests for retrieval of `ConversationPart` details.

Relevant API doc sections: 
- https://developers.intercom.com/intercom-api-reference/reference#conversation-part-model
- https://developers.intercom.com/intercom-api-reference/reference#conversation-model