### PR TITLE
Update README with https bintray repo url #269

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add jcenter to your repositories in `pom.xml` or `settings.xml`:
 <repositories>
   <repository>
     <id>jcenter</id>
-    <url>http://jcenter.bintray.com</url>
+    <url>https://jcenter.bintray.com</url>
   </repository>
 </repositories>
 ```  

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dependencies {
 Add jcenter to your `resolvers` in your `build.sbt`:
 
 ```scala
-resolvers += "jcenter" at "http://jcenter.bintray.com"
+resolvers += "jcenter" at "https://jcenter.bintray.com"
 ```
 
 and add the project to your `libraryDependencies` in your `build.sbt`:


### PR DESCRIPTION
#### Why?
The bintray maven repo now returns an error if the http url is used instead of https. Updating the outdated README to reflect this.

#### How?
Change http://jcenter.bintray.com to https://jcenter.bintray.com in README.md
