### PR TITLE
Add GPG2 singing for Java Jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ hs_err_pid*
 intercom-java/.project
 
 .project
+securing.gpg

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ buildscript {
   }
 }
 
+plugins {
+    id 'signing'
+}
+
 allprojects {
   apply plugin: 'idea'
 }

--- a/intercom-java/build.gradle
+++ b/intercom-java/build.gradle
@@ -69,6 +69,14 @@ bintray {
   }
 }
 
+signing {
+    String keyId = System.getenv('keyId');
+    String gpgPassword = System.getenv('gpgPassword');
+    if (project.hasProperty('signing.keyId') != null  && gpgPassword != null && project.hasProperty('signing.secretKeyRingFile')) {
+      sign configurations.archives
+    }
+}
+
 ext.repo = Grgit.open(project.file('..'))
 
 task printVersion << {


### PR DESCRIPTION
#### Why?
adding signing to intercom java. 

#after assembling 
<img width="304" alt="Screenshot 2021-04-29 at 11 22 14" src="https://user-images.githubusercontent.com/6124835/116537147-bf8f2400-a8dd-11eb-9f20-affd30af29d3.png">


```
!seanhealy/addGPG2Keys ~/src/intercom-java> ./gradlew sign -Psigning.secretKeyRingFile=./securing.gpg -Psigning.password=$gpgPassword -Psigning.keyId=$keyId


Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
6 actionable tasks: 1 executed, 5 up-to-date
!seanhealy/addGPG2Keys ~/src/intercom-java> ./gradlew assemble



Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 0s
5 actionable tasks: 5 up-to-date
!seanhealy/addGPG2Keys ~/src/intercom-java>
```